### PR TITLE
Add toggle to see all errors on default report

### DIFF
--- a/lib/themes/default/report.jade
+++ b/lib/themes/default/report.jade
@@ -2,6 +2,7 @@ h1 Nightwatch Results
 #container
 	if !hideSuccess
 		a.toggleSuccess(href='#') Show/Hide Successes
+		a.toggleError(href='#') Show/Hide Errors
 
 	if testRun.errmessages.length > 0
 		div.errmessages

--- a/lib/themes/default/script.js
+++ b/lib/themes/default/script.js
@@ -13,6 +13,6 @@ $(document).ready(function() {
     $('.package.success').slideToggle();
   });
   $('.toggleError').click(function() {
-    $('.package.error').slideToggle();
+    $('.error h2').click();$('.error h3').click();
   });
 });


### PR DESCRIPTION
This will allow you to see all failed assertions in all test suites at once when you have generated a report from several XML files.
