### PR TITLE
Add filename of XML report to package name.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -80,6 +80,8 @@ var readOpts = {
   entryType: 'files'
 };
 
+var files = [];
+
 async.waterfall([
 
   readdirp.bind(readdirp, readOpts),
@@ -87,6 +89,7 @@ async.waterfall([
   function readFiles(results, next) {
     async.map(results.files, function(result, rnext) {
       fs.readFile(result.fullPath, rnext);
+      files.push(result.name);
     }, next);
   },
 
@@ -101,6 +104,10 @@ async.waterfall([
         next(err, parsedData);
       });
     } else {
+      // add filename of the report
+      for (var i = 0, length = parsedData.length; i < length; i += 1) {
+        parsedData[i].testsuites.filename = files[i];
+      }
       next(null, parsedData);
     }
   },

--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -75,8 +75,11 @@ var normalizers = {
 
         // Sometimes the package name isn't in the
         // xml reports...
-        if (!pkg.name)
-          pkg.name = suite.pkgName;
+        if (!pkg.name) {
+          pkg.name = result.testsuites.filename;
+        } else {
+          pkg.name = result.testsuites.filename + '-' + pkg.name;
+        }
 
         suite.passed = suite.tests - suite.errors - suite.failures;
         suite.isFailure = suite.errors > 0 || suite.failures > 0;

--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -76,9 +76,15 @@ var normalizers = {
         // Sometimes the package name isn't in the
         // xml reports...
         if (!pkg.name) {
-          pkg.name = result.testsuites.filename;
+          if (result.testsuites.filename) {
+            pkg.name = result.testsuites.filename;
+          } else {
+            pkg.name = suite.pkgName;
+          }
         } else {
-          pkg.name = result.testsuites.filename + '-' + pkg.name;
+          if (result.testsuites.filename) {
+            pkg.name = result.testsuites.filename + '-' + pkg.name;
+          }
         }
 
         suite.passed = suite.tests - suite.errors - suite.failures;


### PR DESCRIPTION
In the case of multiple runs across different browsers for the same test,
adding the filename will allow you to distinguish between the results.