### PR TITLE
Specify charset properties to meta tag

### DIFF
--- a/lib/themes/compact-gray/index.jade
+++ b/lib/themes/compact-gray/index.jade
@@ -1,6 +1,7 @@
 doctype html
 html(lang="en")
 	head
+		meta(charset='utf-8')
 		title Nightwatch HTML Report - Compact Gray Theme
 		script(type='text/javascript', src='http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js')
 		style(type="text/css")

--- a/lib/themes/compact/index.jade
+++ b/lib/themes/compact/index.jade
@@ -1,6 +1,7 @@
 doctype html
 html(lang="en")
 	head
+		meta(charset='utf-8')
 		title Nightwatch HTML Report - Compact Theme
 		script(type='text/javascript', src='http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js')
 		style(type="text/css")

--- a/lib/themes/cover/index.jade
+++ b/lib/themes/cover/index.jade
@@ -1,6 +1,7 @@
 doctype html
 html(lang="en")
 	head
+		meta(charset='utf-8')
 		title Nightwatch HTML Report - Cover Theme
 		link(rel="stylesheet", href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css")
 		link(rel="stylesheet", href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap-theme.min.css")

--- a/lib/themes/default-gray/index.jade
+++ b/lib/themes/default-gray/index.jade
@@ -1,6 +1,7 @@
 doctype html
 html(lang="en")
 	head
+		meta(charset='utf-8')
 		title Nightwatch HTML Report - Default Theme
 		script(type='text/javascript', src='http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js')
 		style(type="text/css")

--- a/lib/themes/default/index.jade
+++ b/lib/themes/default/index.jade
@@ -1,6 +1,7 @@
 doctype html
 html(lang="en")
 	head
+		meta(charset='utf-8')
 		title Nightwatch HTML Report - Default Theme
 		script(type='text/javascript', src='http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js')
 		style(type="text/css")

--- a/lib/themes/outlook/index.jade
+++ b/lib/themes/outlook/index.jade
@@ -1,6 +1,7 @@
 doctype html
 html(lang="en")
 	head
+		meta(charset='utf-8')
 		title Nightwatch HTML Report - Outlook Theme
 		style(type="text/css").
 			html,


### PR DESCRIPTION
I start to use nightwatch-html-reporter in my project.
It's very great library!
My web page was written by Japanese.
If test case was included Japanese, test case is garbed.

So I specified charset properties to meta tag as `utf-8` .

Please check my PR, and if it is possible, please merge it!