### PR TITLE
Use https in jquery src

### DIFF
--- a/lib/themes/compact-gray/index.jade
+++ b/lib/themes/compact-gray/index.jade
@@ -3,7 +3,7 @@ html(lang="en")
 	head
 		meta(charset='utf-8')
 		title Nightwatch HTML Report - Compact Gray Theme
-		script(type='text/javascript', src='http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js')
+		script(type='text/javascript', src='https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js')
 		style(type="text/css")
 			include ../default/styles.css
 			include ../compact/styles.css

--- a/lib/themes/compact/index.jade
+++ b/lib/themes/compact/index.jade
@@ -3,7 +3,7 @@ html(lang="en")
 	head
 		meta(charset='utf-8')
 		title Nightwatch HTML Report - Compact Theme
-		script(type='text/javascript', src='http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js')
+		script(type='text/javascript', src='https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js')
 		style(type="text/css")
 			include ../default/styles.css
 			include styles.css

--- a/lib/themes/cover/index.jade
+++ b/lib/themes/cover/index.jade
@@ -130,7 +130,7 @@ html(lang="en")
 			    width: 800px;
 			  }
 			}
-		script(type='text/javascript', src='http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js')
+		script(type='text/javascript', src='https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js')
 
 	body
 		div.site-wrapper

--- a/lib/themes/default-gray/index.jade
+++ b/lib/themes/default-gray/index.jade
@@ -3,7 +3,7 @@ html(lang="en")
 	head
 		meta(charset='utf-8')
 		title Nightwatch HTML Report - Default Theme
-		script(type='text/javascript', src='http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js')
+		script(type='text/javascript', src='https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js')
 		style(type="text/css")
 			include ../default/styles.css
 			include styles.css

--- a/lib/themes/default/index.jade
+++ b/lib/themes/default/index.jade
@@ -3,7 +3,7 @@ html(lang="en")
 	head
 		meta(charset='utf-8')
 		title Nightwatch HTML Report - Default Theme
-		script(type='text/javascript', src='http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js')
+		script(type='text/javascript', src='https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js')
 		style(type="text/css")
 			include styles.css
 


### PR DESCRIPTION
If the html report is served over https, the browser will block the request, resulting in 

> Uncaught ReferenceError: $ is not defined