### PR TITLE
Add ability to make unique report file with testsuite name

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -37,7 +37,14 @@ module.exports = function(options) {
   logger.setLevel(opts.logLevel);
 
   this.fn = function(results, done) {
-
+    var testName = '';
+    var oneObject = Object.keys(results.modules);      
+    oneObject.forEach(function (nextLevel) {
+            testName = nextLevel;
+    });
+    if (opts.separateReportPerSuite) {
+       opts.reportFilename = opts.reportFilename.replace(/\.html/,'') + '-' + testName.replace(/\\/g,'-') + '.html';
+    }
     var generate = function generate(next) {
 
       async.waterfall([


### PR DESCRIPTION
I created a new option separateReportPerSuite, if this is true, each
test suite report will be genereated in unique file, and the report file
name will contain the suite name. It is needed for easier result
analyses in case of parallel execution.
