### PR TITLE
Minor wording update

### DIFF
--- a/lib/themes/cover/index.jade
+++ b/lib/themes/cover/index.jade
@@ -147,7 +147,7 @@ html(lang="en")
 					else
 						div.inner.cover.failure
 							h1.status &#10005;
-							h1.cover-heading There were a couple of problems :(
+							h1.cover-heading There were a few problems :(
 							p.lead.
 								It's ok though, we're gonna get through this.
 							div.suites


### PR DESCRIPTION
Using "couple" when there are more than two failures is unnecessarily confusing, particularly for non-native speakers.